### PR TITLE
fix: use effect

### DIFF
--- a/src/components/TheDarkMode.tsx
+++ b/src/components/TheDarkMode.tsx
@@ -18,12 +18,16 @@ const TheDarkModeButton: React.FC<{ toggle: () => void; mode: boolean }> = ({ to
  * @returns TheDarkMode component is being returned, which renders a div containing TheDarkModeButton component.
  */
 const TheDarkMode: React.FC = () => {
-  const [darkMode, setDarkMode] = useState<boolean>(
-    typeof window !== 'undefined' ? localStorage.getItem('darkMode') === 'true' : false
-  )
+  const [darkMode, setDarkMode] = useState<boolean>(localStorage.getItem('darkMode') === 'true')
 
   const switchMode = useCallback(() => {
     setDarkMode((mode) => !mode)
+  }, [])
+
+  useEffect(() => {
+    if (localStorage.getItem('darkMode') === 'true') {
+      setDarkMode(true)
+    }
   }, [])
 
   useEffect(() => {

--- a/src/components/TheNavBar.tsx
+++ b/src/components/TheNavBar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { TbGitPullRequestDraft } from 'react-icons/tb'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import Link from 'next/link'
 
@@ -10,9 +10,10 @@ import TheDarkMode from '@/components/TheDarkMode'
 
 /** This is a React functional component that renders a logo with a link to the home page of the website. */
 function TheLogo() {
-  const [currentMode] = useState<boolean | null>(
-    typeof window !== 'undefined' ? localStorage.getItem('darkMode') === 'true' : null
-  )
+  const [currentMode, setCurrentMode] = useState<boolean | undefined>(undefined)
+  useEffect(() => {
+    setCurrentMode(localStorage.getItem('darkMode') === 'true')
+  }, [])
   return (
     <div className="h-12 w-12 flex-shrink-0 rounded-md bg-slate-700 ring-2 ring-black ring-opacity-5 transition duration-300 ease-in-out hover:scale-105 dark:bg-gray-100">
       <Link href="/" className="items-center">


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18cc41j58kDdy4ZrGaV5PaqywSOxbwiU%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=oAE3N0s)
local storage